### PR TITLE
remove wrong citation

### DIFF
--- a/citing.md
+++ b/citing.md
@@ -462,13 +462,6 @@ University of Geneva, Switzerland.
   Discretizations Applied to Wave Propagation Problems. Journal of Computational Physics, 231(4),
   pp 2067-2091, 2012. doi: https://doi.org/10.1016/j.jcp.2011.11.024
 
-#### ParsaniKetchesonDeconinck3S94, ParsaniKetchesonDeconinck3S184, ParsaniKetchesonDeconinck3S105, ParsaniKetchesonDeconinck3S205
-
-- T. Toulorge, W. Desmet. Optimized Explicit Runge-Kutta Schemes for the Spectral Difference
-  Method Applied to Wave Propagation Problems. 2013 Society for Industrial and Applied
-  Mathematics Journal on Scientific Computing, 35(2), pp A957-A986, 2013. doi:
-  https://doi.org/10.1137/120885899
-
 #### AB3, AB4, AB5, ABM32, ABM43, ABM54, VCAB3, VCAB4, VCAB5, VCABM, VACBM3, VCABM4, VCABM5
 
 - E. Hairer, S. P. Norsett, G. Wanner, Solving Ordinary Differential Equations I, Nonstiff


### PR DESCRIPTION
The removed part was a strange mix of the citations for `DGLDDRK73_C, DGLDDRK84_C, DGLDDRK84_F` and `ParsaniKetchesonDeconinck3S32, ...`.