### PR TITLE
Request for extension of NeuroTabModels.jl Project

### DIFF
--- a/small_grants.md
+++ b/small_grants.md
@@ -334,7 +334,7 @@ development skills and test-driven development of a large code base is required.
 
 ## Add support for TabM architecture in NeuroTabModels.jl and remove Zygote.jl dependency (\$1800)
 
-**In Progress**: Claimed by Aditya Pandey for the time period of January 20, 2026 - March 12, 2026.
+**In Progress**: Claimed by Aditya Pandey for the time period of January 20, 2026 - March 20, 2026.
 
 [NeuroTabModels.jl](https://github.com/Evovest/NeuroTabModels.jl) is a library for training neural networks on tabular data. It currently supports a limited set of architectures: MLP, ResNets and NeuroTrees, and is built on top of Flux.jl and Zygote.jl.
 


### PR DESCRIPTION
I request one more week extension for the project, from the last update(https://github.com/SciML/sciml.ai/pull/223) the 
1. Migration work to Lux.jl and Reactant.jl is completed.(https://github.com/Evovest/NeuroTabModels.jl/pull/25)
2. TabM architecture support and embedding module work is functional and almost complete.(https://github.com/Evovest/NeuroTabModels.jl/pull/29) . We are verifying our work with the original Python implementation by using weights of the TabM pytorch package. 
Have a look at this for more details 
(https://github.com/AdityaPandeyCN/NeuroTabModels.jl/tree/verification/test/tabm_verification)
