### PR TITLE
Declare AdaptiveSDE benchmark fix (SciMLBenchmarks.jl#126) for Small Grants

### DIFF
--- a/small_grants.md
+++ b/small_grants.md
@@ -197,6 +197,52 @@ solvers in a standard SciMLBenchmarks benchmark build.
 
 **Reviewers**: Chris Rackauckas
 
+## Fix and Update the AdaptiveSDE Benchmark Set (\$400)
+
+**In Progress**: Claimed by Jitendra Verma for the time period of June 19, 2026 - July 19, 2026.
+
+The [AdaptiveSDE benchmarks](https://github.com/SciML/SciMLBenchmarks.jl/tree/master/benchmarks/AdaptiveSDE)
+(`AdaptiveEfficiencyTests.jmd` and `qmaxDetermination.jmd`) compare the adaptive
+stepsize rejection sampling with memory (RSwM) algorithms and `qmax` settings for
+the SRIW1 adaptive SDE solver. These benchmarks no longer build, and the core
+blocker is that they drive parallelism manually with `Distributed`
+(`addprocs(2)`, `@everywhere`, and `ParallelDataTransfer.sendto(workers(), ...)`),
+which the Weave-based SciMLBenchmarks build does not reliably execute — workers do
+not survive the weave and process state is not transferred. The primary fix is to
+remove the manual worker management and express the Monte Carlo runs through the
+standard `EnsembleProblem` interface (e.g. `EnsembleThreads()`, or a
+weave-compatible `EnsembleDistributed()`), which the code already partially uses.
+
+On top of that, the benchmarks have bitrotted against the current SciML interfaces:
+`qmaxDetermination.jmd` still imports the removed `DiffEqMonteCarlo` package, both
+files call `DiffEqBase.calculate_monte_errors` (which has since moved out of
+`DiffEqBase`), and the `SDEProblemLibrary` problem accessors and solver keyword
+arguments need updating. The goal is to make both benchmarks weave to completion
+under the standard build and regenerate their work-precision/efficiency diagrams on
+current SciML interfaces.
+
+**Information to Get Started**: The
+[Contributing Section of the SciMLBenchmarks README](https://github.com/SciML/SciMLBenchmarks.jl?tab=readme-ov-file#contributing)
+describes how to contribute to the benchmarks. The benchmark results are generated
+using the benchmark server. Start by replacing the manual `Distributed` /
+`ParallelDataTransfer` plumbing with the ensemble interface so the files weave under
+the build server; then port the Monte Carlo error calculations to the current
+ensemble-error API, update the `Project.toml`/`Manifest.toml` dependencies, and
+verify both files weave to completion.
+
+**Related Issues**: [https://github.com/SciML/SciMLBenchmarks.jl/issues/126](https://github.com/SciML/SciMLBenchmarks.jl/issues/126)
+
+**Success Criteria**: Both `AdaptiveEfficiencyTests.jmd` and `qmaxDetermination.jmd`
+weave to completion in the standard SciMLBenchmarks build (without relying on manual
+`addprocs`/`@everywhere` worker management) and regenerate their
+efficiency/work-precision diagrams using current SciML interfaces.
+
+**Recommended Skills**: Familiarity with Julia and the SciML ecosystem; basic
+knowledge of stochastic differential equations and adaptive solvers; comfort with
+Julia's `Distributed`/ensemble parallelism and the Weave build pipeline.
+
+**Reviewers**: Chris Rackauckas
+
 # Successful Projects Archive
 
 These are the previous SciML small grants projects which have successfully concluded and paid out.

--- a/small_grants.md
+++ b/small_grants.md
@@ -197,7 +197,7 @@ solvers in a standard SciMLBenchmarks benchmark build.
 
 **Reviewers**: Chris Rackauckas
 
-## Fix and Update the AdaptiveSDE Benchmark Set (\$400)
+## Fix and Update the AdaptiveSDE Benchmark Set (\$200)
 
 **In Progress**: Claimed by Jitendra Verma for the time period of June 19, 2026 - July 19, 2026.
 


### PR DESCRIPTION
This PR adds a new entry to the **List of Current Projects** in `small_grants.md` and declares interest in it, following the "Declaring for a Project" / "Adding Projects to the List" process. It corresponds to [SciMLBenchmarks.jl#126](https://github.com/SciML/SciMLBenchmarks.jl/issues/126), where I've also commented with a scope of the work ([comment](https://github.com/SciML/SciMLBenchmarks.jl/issues/126#issuecomment-4752151105)).

### Re-scope note

Per Chris's feedback, the real blocker isn't just the deprecated `DiffEqMonteCarlo` / `calculate_monte_errors` references — it's that the benchmarks drive parallelism manually with `Distributed` (`addprocs`, `@everywhere`, `ParallelDataTransfer.sendto`), which the Weave-based build can't reliably execute. The primary fix is to move the Monte Carlo runs onto the standard `EnsembleProblem` interface; the API/dependency updates are secondary cleanup. The suggested payout is **\$400** to match the comparable "Fix and Update the Simple Handwritten PDEs as ODEs Benchmark Set (\$400)" grant. Payout and reviewer remain placeholders for the Steering Council to confirm or adjust.

### Declaration details

- **Full legal name**: Jitendra Verma
- **CV**: https://jitendravjh.in/resume/resume.pdf
- **Short bio / background**: Final-year B.Tech Computer Science student at Uka Tarsadia University (Surat, India). I have prior merged contributions to the SciML ecosystem — I implemented two adaptive loss functions (`SoftAdaptAdaptiveLoss` and `ReLOBRaLoAdaptiveLoss`) and documentation improvements in NeuralPDE.jl (SciML/NeuralPDE.jl#1054, #1055, #1057), and have contributed to TuringLang. I work across Julia and Python and am comfortable with the SciML package and benchmarking workflow (Project/Manifest environments, weaving `.jmd` benchmarks).
- **Project of interest**: *Fix and Update the AdaptiveSDE Benchmark Set* — removing the manual `Distributed` plumbing in `AdaptiveEfficiencyTests.jmd` and `qmaxDetermination.jmd` so they weave under the standard build, and modernizing them to current SciML interfaces so they regenerate their efficiency/work-precision diagrams.

Happy to adjust the entry (payout, reviewer, scope, or timeframe) per the Steering Council's feedback before this is merged.
